### PR TITLE
Update ChatSession.js

### DIFF
--- a/src/components/Chat/ChatSession.js
+++ b/src/components/Chat/ChatSession.js
@@ -12,13 +12,14 @@ const SYSTEM_EVENTS = Object.values(ContentType.EVENT_CONTENT_TYPE);
 class ChatJSClient {
   session = null;
 
-  constructor(chatDetails) {
+  constructor(chatDetails,region, stage) {
     // Creating a chatSession object with Chat.JS
     // Other operations (connecting, sending message, ...) are then done by interacting
     // with the chatSession object (this.session)
     this.session = connect.ChatSession.create({
       chatDetails: chatDetails.startChatResult,
-      type: "CUSTOMER"
+      type: "CUSTOMER",
+      options: {region: region}
     });
   }
 


### PR DESCRIPTION

*Issue #, if available:* 1

*Description of changes:*
Updating ChatJS constructor (L22) to accept the region and stage parameters passed by the ChatSession constructor (L106). This is a bug that causes WS initiation failures in all regions except us-west-2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
