### PR TITLE
Bug fixes: IE styling and websocket transcript race condition

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,6 @@
 {
   "plugins": [
-    ["react-intl", {
-        "messagesDir": "./src/localization/",
-        "extractSourceLocation": true
-    }]
+    "emotion"
   ],
   "presets": [
     "react-app"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "chat",
   "dependencies": {
     "@babel/runtime": "7.9.2",
+    "@emotion/core": "^10.0.35",
     "@svgr/webpack": "^5.4.0",
     "@types/jest": "^26.0.19",
     "amazon-connect-chatjs": "^1.1.0",

--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -26,6 +26,7 @@ const HeaderWrapper = styled.div`
   padding: 20px;
   color: #fff;
   border-radius: 3px;
+  flex-shrink: 0;
 `
 const WelcomeText  = styled(Text)`
   padding-bottom: 10px;

--- a/src/components/Chat/ChatTranscriptor/ChatTranscriptor.js
+++ b/src/components/Chat/ChatTranscriptor/ChatTranscriptor.js
@@ -23,7 +23,7 @@ const TranscriptBody = styled.div`
 
 const TranscriptWrapper = styled(ChatTranscriptScroller)`
   order: 2;
-  flex: 1 1 0;
+  flex: 1 1 auto;
   background: ${props => props.theme.chatTranscriptor.background};
 `;
 

--- a/src/context/LanguageContext.js
+++ b/src/context/LanguageContext.js
@@ -5,7 +5,7 @@ import React from 'react';
 import messages_en from '../localization/en_US.json';
 import messages_fr from '../localization/fr_FR.json';
 import { addLocaleData, IntlProvider } from 'react-intl';
-import { LANGUAGE_KEY, LANGUAGES } from '../constants/global';
+import { LANGUAGES } from '../constants/global';
 
 // add for all languages
 export const labels = {
@@ -22,7 +22,7 @@ export class LanguageProvider extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedLanguage: this.getLanguageDetails(localStorage.getItem(LANGUAGE_KEY)) || this.getLanguageDetails("en_US")
+      selectedLanguage: this.getLanguageDetails("en_US")
     };
     this.loadLanguages();
   }
@@ -31,18 +31,17 @@ export class LanguageProvider extends React.Component {
     return LANGUAGES.find(function (lan) {
       return lan.id === language;
     });
-  }
+  };
 
   loadLanguages = () => {
     let elLocaleData = require('react-intl/locale-data/en');
     addLocaleData(elLocaleData);
-  }
+  };
 
   changeLanguage = (languageObject) => {
     this.setState({ selectedLanguage: languageObject });
     console.log(languageObject);
     this.loadLanguages();
-    localStorage.setItem(LANGUAGE_KEY, languageObject.id);
   };
 
   render() {


### PR DESCRIPTION
*Description of changes:*
1. [IE11] Add `flex: 1 1 auto`  to the transcript to address the chat window not sizing the flex column children correctly: https://stackoverflow.com/questions/37905749/flexbox-not-working-in-internet-explorer-11
2. [IE11] Add `flex-shrink` to the Header so that the header message stays within the bounds of the div.
3. Add `@emotion/core` back to the dependencies and babel config, needed for the React spinners.
4. Add a flag `isOutgoingMessageInFlight` to avoid duplicate message render. With spotty internet, the websocket message will sometimes come through before the SendMessage http call returns, so we will render the message twice in the transcript. This flag prevents a customer side render if the message is still in flight.
5. Remove local storage actions in the localization code.
6. Change `endChat` to an async function as it wasn't previously returning its promise.

*Testing done:*
Tested all IE fixes in IE11 in Windows VM, and verified on Firefox and Chrome.

Tested duplicate message fix using network simulator in devtools, to simulate a slow 3g connection.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
