### PR TITLE
Change textContent back to innerText, for comparing events while typing

### DIFF
--- a/src/components/Chat/ChatComposer/ChatComposer.js
+++ b/src/components/Chat/ChatComposer/ChatComposer.js
@@ -160,7 +160,7 @@ export default function ChatComposer({ addMessage, addAttachment, onTyping, cont
   }, [attachment]);
 
   function hasSameContent(event) {
-    return event.target.textContent === message;
+    return event.target.innerText === message;
   }
 
   function onInput(event) {


### PR DESCRIPTION
Still investigating why this makes a difference here, but in Chrome + Firefox, `event.target.textContent` lags one character behind (could be an issue with the text input react library we use https://github.com/Andarist/react-textarea-autosize#readme).

Changing back to `innerText` for the typing check, fixes issue and does not regress behavior in IE11.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
