### PR TITLE
Successful Transfer event value doesn't match the Model's content type mappping

### DIFF
--- a/src/components/Chat/datamodel/Model.js
+++ b/src/components/Chat/datamodel/Model.js
@@ -15,7 +15,7 @@ export const ContentType = {
         TYPING: "application/vnd.amazonaws.connect.event.typing",
         PARTICIPANT_JOINED: "application/vnd.amazonaws.connect.event.participant.joined",
         PARTICIPANT_LEFT: "application/vnd.amazonaws.connect.event.participant.left",
-        TRANSFER_SUCCEEDED: "application/vnd.amazonaws.connect.event.transfer.succeed",
+        TRANSFER_SUCCEEDED: "application/vnd.amazonaws.connect.event.transfer.succeeded",
         TRANSFER_FAILED: "application/vnd.amazonaws.connect.event.transfer.failed",
         CONNECTION_ACKNOWLEDGED: "application/vnd.amazonaws.connect.event.connection.acknowledged",
         CHAT_ENDED: "application/vnd.amazonaws.connect.event.chat.ended"


### PR DESCRIPTION
*Issue #, if available:*
To handle the event when a chat customer has been successfully transferred to a different queue or agent, we have to check the event item's content type to the datamodel's mapping. Right there is no match for successful transfer because it's looking for a value of `application/vnd.amazonaws.connect.event.transfer.succeed`:

https://github.com/amazon-connect/amazon-connect-chat-interface/blob/083f8348ce1849dbd18f784c9af1c2aa2fe569cf/src/components/Chat/datamodel/Model.js#L18

*Description of changes:*
The type value should be `succeeded` not `succeed`:
![image](https://user-images.githubusercontent.com/50115984/121936221-648f8000-cd17-11eb-8acf-ca701b80959e.png)


It is listed in this [README](https://github.com/amazon-connect/amazon-connect-chatjs/blob/master/README.md#:~:text=left-,application%2Fvnd.amazonaws.connect,connect.event.transfer.failed,-application) example.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
