### PR TITLE
remove WatchMissingNodeModulesPlugin to repair dev-build

### DIFF
--- a/configuration/webpack.config.dev.js
+++ b/configuration/webpack.config.dev.js
@@ -6,7 +6,6 @@ const resolve = require('resolve');
 const webpack = require('webpack');
 const PnpWebpackPlugin = require('pnp-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
-const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin');
 const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
 const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
 const getClientEnvironment = require('./env');
@@ -362,11 +361,6 @@ module.exports = {
     // a plugin that prints an error when you attempt to do this.
     // See https://github.com/facebook/create-react-app/issues/240
     new CaseSensitivePathsPlugin(),
-    // If you require a missing module and then `npm install` it, you still have
-    // to restart the development server for Webpack to discover it. This plugin
-    // makes the discovery automatic so you don't have to restart.
-    // See https://github.com/facebook/create-react-app/issues/186
-    new WatchMissingNodeModulesPlugin(paths.appNodeModules),
     // Moment.js is an extremely popular library that bundles large locale files
     // by default due to how Webpack interprets its code. This is a practical
     // solution that requires the user to opt into importing specific locales.


### PR DESCRIPTION
*Issue #:* #75

*Description of changes:*

Customer unable to run `npm run dev-build` using `webpack.config.dev.js` because of depedency update (which tested in NodeCI).

*Details:*

`webpack.config.dev.js` contained a deprecated plugin `WatchMissingNodeModulesPlugin`. Recent changes to `react-utils` dependency have removed this file because they are migrating to webpack v5. Refer to this [StackOverflow](https://stackoverflow.com/questions/68827938/when-i-update-react-dev-utils-to-the-next-version-i-cant-find-typescriptforma) question for more details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
