### PR TITLE
Fix bug where customer is still able to send message after agent ends…

### DIFF
--- a/src/.idea/.gitignore
+++ b/src/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/src/.idea/codeStyles/Project.xml
+++ b/src/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
+  </code_scheme>
+</component>

--- a/src/.idea/codeStyles/codeStyleConfig.xml
+++ b/src/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/src/.idea/misc.xml
+++ b/src/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/src/.idea/modules.xml
+++ b/src/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/src.iml" filepath="$PROJECT_DIR$/.idea/src.iml" />
+    </modules>
+  </component>
+</project>

--- a/src/.idea/runConfigurations.xml
+++ b/src/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/src/.idea/src.iml
+++ b/src/.idea/src.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/.idea/vcs.xml
+++ b/src/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/src/components/Chat/ChatComposer/ChatComposer.js
+++ b/src/components/Chat/ChatComposer/ChatComposer.js
@@ -323,8 +323,6 @@ export default function ChatComposer({ addMessage, addAttachment, onTyping, cont
 
   const defaultComposer = (
     <DefaultChatComposerWrapper>
-      {contactStatus === CONTACT_STATUS.CONNECTED && (
-        <React.Fragment>
           {composerConfig && composerConfig.attachmentsEnabled && (
             <PaperClipContainer
               tabIndex={0}
@@ -389,10 +387,17 @@ export default function ChatComposer({ addMessage, addAttachment, onTyping, cont
           <SendMessageButtonContainer>
             <SendMessageButton isActive={!!message || attachment} sendMessage={sendMessage.bind(this)} />
           </SendMessageButtonContainer>
-        </React.Fragment>
-      )}
     </DefaultChatComposerWrapper>
   );
 
-  return <ChatComposerWrapper>{composerConfig && composerConfig.richMessagingEnabled ? richMessagingComposer : defaultComposer}</ChatComposerWrapper>;
+  return (
+    <ChatComposerWrapper>
+      { contactStatus === CONTACT_STATUS.CONNECTED && (
+          composerConfig && composerConfig.richMessagingEnabled
+              ? richMessagingComposer
+              : defaultComposer)
+      }
+    </ChatComposerWrapper>
+  );
+>>>>>>> 2b5347a (Fix bug where customer is still able to send message after agent ends chat)
 }


### PR DESCRIPTION
… chat

*Issue #, if available:*
* Fix issue where customer is still able to send message after chat is ended by agent. This was only an issue in widgets with rich messaging enabled

*Description of changes:*
* only show the editor (default and rich) if contact status is connected


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
