### PR TITLE
Fix bug where customer is still able to send message after agent ends…

### DIFF
--- a/src/components/Chat/ChatComposer/ChatComposer.js
+++ b/src/components/Chat/ChatComposer/ChatComposer.js
@@ -323,8 +323,6 @@ export default function ChatComposer({ addMessage, addAttachment, onTyping, cont
 
   const defaultComposer = (
     <DefaultChatComposerWrapper>
-      {contactStatus === CONTACT_STATUS.CONNECTED && (
-        <React.Fragment>
           {composerConfig && composerConfig.attachmentsEnabled && (
             <PaperClipContainer
               tabIndex={0}
@@ -389,10 +387,16 @@ export default function ChatComposer({ addMessage, addAttachment, onTyping, cont
           <SendMessageButtonContainer>
             <SendMessageButton isActive={!!message || attachment} sendMessage={sendMessage.bind(this)} />
           </SendMessageButtonContainer>
-        </React.Fragment>
-      )}
     </DefaultChatComposerWrapper>
   );
 
-  return <ChatComposerWrapper>{composerConfig && composerConfig.richMessagingEnabled ? richMessagingComposer : defaultComposer}</ChatComposerWrapper>;
+  return (
+    <ChatComposerWrapper>
+      { contactStatus === CONTACT_STATUS.CONNECTED && (
+          composerConfig && composerConfig.richMessagingEnabled
+              ? richMessagingComposer
+              : defaultComposer)
+      }
+    </ChatComposerWrapper>
+  );
 }


### PR DESCRIPTION
… chat

*Issue #, if available:*\
* Fix issue where customer is still able to send message after chat is ended by agent. This was only an issue in widgets with rich messaging enabled

*Description of changes:*
* only show the editor (default and rich) if contact status is connected


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
