### PR TITLE
always consume latest version of npm chatjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@emotion/core": "^10.0.35",
     "@svgr/webpack": "^6.2.1",
     "@types/jest": "^26.0.19",
-    "amazon-connect-chatjs": "^1.3.0",
+    "amazon-connect-chatjs": "*",
     "core-js": "^3.8.3",
     "draft-js": "^0.11.7",
     "emoji-mart": "^3.0.1",


### PR DESCRIPTION
# Blocked by PR #121

*Issue #, if available:*

*Description of changes:*
Mirror internal workflow and consume latest version of ChatJS from npm.

Team already does manual local test with chat-interface on each pull request to ChatJS.

> **Note:** `package-lock.json` will need to be regenerated - not included to avoid merge conflicts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
