### PR TITLE
Add error messaging on attachment rejection

### DIFF
--- a/src/components/Chat/ChatTranscriptor/ChatMessages/ChatMessage.js
+++ b/src/components/Chat/ChatTranscriptor/ChatMessages/ChatMessage.js
@@ -256,6 +256,11 @@ export class ParticipantMessage extends PureComponent {
       if (this.props.messageDetails.Attachments && this.props.messageDetails.Attachments.length > 0) {
         content = this.props.messageDetails.Attachments[0];
         contentType = content.ContentType;
+        if (content.Status === AttachmentStatus.REJECTED && error === undefined) {
+          error = {
+            message: "Attachment was rejected."
+          }
+        }
       } else {
         content = {
           AttachmentName: this.props.messageDetails.content.name,

--- a/src/components/Chat/ChatTranscriptor/ChatTranscriptor.test.js
+++ b/src/components/Chat/ChatTranscriptor/ChatTranscriptor.test.js
@@ -134,11 +134,7 @@ const mockAttachmentsTranscript = [
     id: "2210",
     type: ATTACHMENT_MESSAGE,
     transportDetails: {
-      direction: "Outgoing",
-      error: {
-        type: AttachmentErrorType.InternalServerException,
-        message: "transport error",
-      },
+      direction: "Outgoing"
     },
     Attachments: [
       {
@@ -203,9 +199,15 @@ test("Should be able to see and download an attachment", () => {
 test("Should not be able to download an rejected attachment", () => {
   renderElement(mockProps);
   expect(mockTranscriptor.getByText("testDownloadError.pdf")).toBeDefined();
-  expect(mockTranscriptor.getByText("transport error")).toBeDefined();
   fireEvent.click(mockTranscriptor.getByText("testDownloadError.pdf"));
   expect(mockProps.downloadAttachment).toHaveBeenCalledTimes(0);
+});
+
+test("Should show error message for rejected attachment", () => {
+  renderElement(mockProps);
+  const errorMessage = document.querySelector('span');
+  expect(errorMessage).toBeInTheDocument();
+  expect(errorMessage).toHaveTextContent('Attachment was rejected.');
 });
 
 test("Should be able to render bold, italics, numbered list, bulleted list and hyperlink, but not image", () => {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a new error message `Attachment was rejected.` when an attachment is rejected by the backend.

<img width="1051" alt="image" src="https://github.com/amazon-connect/amazon-connect-chat-interface/assets/17178403/376456e7-a378-47be-b48c-2b148bd4fad1">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
