### PR TITLE
reduce non-critical Dependabot warnings and ignore husky package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       - dependency-name: "webpack"
+      - dependency-name: "husky"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reduce non-critical dependabot warnings, we are not able to address and test all of them.

Husky configuration is not backwards compatible, and it is dev dependency that we don't need to upgrade.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
