### PR TITLE
fix: enable ChatEvents for hosted widget custom bundle usage

### DIFF
--- a/src/components/Chat/Chat.js
+++ b/src/components/Chat/Chat.js
@@ -58,7 +58,7 @@ const ChatComposerWrapper = styled.div`
 const HeaderWrapper = styled.div`
   background: #3F5773;
   text-align: center;
-  padding: 20px;
+  padding: 16px;
   color: #fff;
   border-radius: 3px;
   flex-shrink: 0;
@@ -96,7 +96,7 @@ function Header({ headerConfig }){
 }
 
 const textInputRef = React.createRef();
-const HEADER_HEIGHT = 51;
+const HEADER_HEIGHT = 115;
 
 export default class Chat extends Component {
   constructor(props) {
@@ -170,6 +170,7 @@ export default class Chat extends Component {
 
   closeChat() {
     this.props.chatSession.closeChat();
+    this.props.onEnded();
   }
 /*
   Note: For Mobile layout: divided into 3 sections

--- a/src/components/Chat/ChatContainer.js
+++ b/src/components/Chat/ChatContainer.js
@@ -9,6 +9,7 @@ import ChatSession from "./ChatSession";
 import { initiateChat } from "./ChatInitiator";
 import EventBus from "./eventbus";
 import "./ChatInterface";
+import './ChatEvents';
 import { defaultTheme } from "connect-theme";
 import { FlexRowContainer } from "connect-theme/Helpers";
 import { CHAT_FEATURE_TYPES } from "./constants";

--- a/src/components/Chat/ChatEvents.js
+++ b/src/components/Chat/ChatEvents.js
@@ -1,0 +1,99 @@
+/**
+ * Simple utitlity for Event subscription
+ */
+import EventBus from './eventbus';
+
+export class ChatEvents {
+  constructor() {
+    EventBus.on('endChat', this.endChat.bind(this));
+    EventBus.on('loadChat', this.loadChat.bind(this));
+    EventBus.on('startNewChat', this.startNewChat.bind(this));
+    EventBus.on(
+      'pushNotificationEligibleMessageReceived',
+      this.approvePushNotificationEligibleMessageReceived.bind(this),
+    );
+    EventBus.on('agentEndChat', this.agentEndChat.bind(this));
+    EventBus.on('escalateToVoice', this.escalateToVoice.bind(this));
+  }
+
+  _eventHandlers = {
+    'chat-disconnected': [],
+    'chat-loading': [],
+    'chat-start-new': [],
+    'push-notification-eligible-message-received': [],
+    'agent-end-chat': [],
+    'voice-escalation': [],
+  };
+
+  onVoiceEscalation(callback) {
+    this.on('voice-escalation', function (...rest) {
+      callback(...rest);
+    });
+  }
+
+  onChatEnded(callback) {
+    this.on('chat-disconnected', function (...rest) {
+      callback(...rest);
+    });
+  }
+
+  onStartNewChat(callback) {
+    this.on('chat-start-new', function (...rest) {
+      callback(...rest);
+    });
+  }
+
+  onChatLoading(callback) {
+    this.on('chat-loading', function (...rest) {
+      callback(...rest);
+    });
+  }
+  onPushNotificationEligibleMessageReceived(callback) {
+    this.on('push-notification-eligible-message-received', function (...rest) {
+      callback(...rest);
+    });
+  }
+
+  onAgentEndChat(callback) {
+    this.on('agent-end-chat', function (...rest) {
+      callback(...rest);
+    });
+  }
+
+  on(eventType, handler) {
+    if (this._eventHandlers[eventType].indexOf(handler) === -1) {
+      this._eventHandlers[eventType].push(handler);
+    }
+  }
+
+  _triggerEvent(eventType, payload) {
+    this._eventHandlers[eventType].forEach((handler) => {
+      handler(payload);
+    });
+  }
+
+  escalateToVoice(chatContactId) {
+    this._triggerEvent('voice-escalation', chatContactId);
+  }
+
+  endChat() {
+    this._triggerEvent('chat-disconnected');
+  }
+
+  loadChat() {
+    this._triggerEvent('chat-loading');
+  }
+
+  startNewChat() {
+    this._triggerEvent('chat-start-new');
+  }
+  approvePushNotificationEligibleMessageReceived() {
+    this._triggerEvent('push-notification-eligible-message-received');
+  }
+  agentEndChat() {
+    this._triggerEvent('agent-end-chat');
+  }
+}
+
+window.connect = window.connect || {};
+window.connect.ChatEvents = window.connect.ChatEvents || new ChatEvents();

--- a/src/components/Chat/ChatEvents.test.js
+++ b/src/components/Chat/ChatEvents.test.js
@@ -1,0 +1,44 @@
+import { ChatEvents } from './ChatEvents';
+import EventBus from './eventbus';
+
+describe('ChatEvents', () => {
+  let myChatEvent = new ChatEvents();
+  let myFn;
+  beforeEach(() => {
+    myFn = jest.fn();
+  });
+
+  afterEach(() => {
+    expect(myFn).toBeCalled();
+  });
+
+  test('escalateToVoice event', () => {
+    myChatEvent.onVoiceEscalation(myFn);
+    EventBus.trigger('escalateToVoice', {});
+  });
+
+  test('agentEndChat event', () => {
+    myChatEvent.onAgentEndChat(myFn);
+    EventBus.trigger('agentEndChat', {});
+  });
+
+  test('endChat event', () => {
+    myChatEvent.onChatEnded(myFn);
+    EventBus.trigger('endChat', {});
+  });
+
+  test('loadChat event', () => {
+    myChatEvent.onChatLoading(myFn);
+    EventBus.trigger('loadChat', {});
+  });
+
+  test('startNewChat event', () => {
+    myChatEvent.onStartNewChat(myFn);
+    EventBus.trigger('startNewChat', {});
+  });
+
+  test('pushNotificationEligibleMessageReceived event', () => {
+    myChatEvent.onPushNotificationEligibleMessageReceived(myFn);
+    EventBus.trigger('pushNotificationEligibleMessageReceived', {});
+  });
+});

--- a/src/components/Chat/ChatSession.js
+++ b/src/components/Chat/ChatSession.js
@@ -6,6 +6,7 @@ import { CONTACT_STATUS } from "../../constants/global";
 import { modelUtils } from "./datamodel/Utils";
 import { ContentType, PARTICIPANT_MESSAGE, Direction, Status, ATTACHMENT_MESSAGE, AttachmentErrorType, PARTICIPANT_TYPES } from "./datamodel/Model";
 import { getTimeFromTimeStamp } from "../../utils/helper";
+import Eventbus from './eventbus';
 import isJson from "is-json";
 
 const SYSTEM_EVENTS = Object.values(ContentType.EVENT_CONTENT_TYPE);
@@ -650,6 +651,7 @@ class ChatSession {
   _handleEndedEvent() {
     this._updateContactStatus(CONTACT_STATUS.ENDED);
     this._triggerEvent("chat-disconnected");
+    Eventbus.trigger('agentEndChat', {});
   }
 
   // TYPING PARTICIPANTS


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/amazon-connect/amazon-connect-chat-ui-examples/pull/141
- https://github.com/amazon-connect/amazon-connect-chat-interface/pull/143
- https://github.com/amazon-connect/amazon-connect-chat-interface/pull/161
- https://github.com/amazon-connect/amazon-connect-chat-interface/pull/181

*Description of changes:*

Make fixes so GitHub bundle file can be used with Hosted Widget script.

GitHub code did not have `ChatEvent.js` file, which had line: `window.connect.ChatEvents = window.connect.ChatEvents || new ChatEvents();`

#### Changes

- Create `ChatEvent.js` file
- Fix header styling issues

https://github.com/amazon-connect/amazon-connect-chat-interface/assets/60903378/3b31fb23-80e2-43e1-984c-538bf9a1efc3

<img width="862" alt="working_with_markdown" src="https://github.com/amazon-connect/amazon-connect-chat-interface/assets/60903378/1a533130-6b35-4351-b76f-338bcd9d1334">

<img width="741" alt="working_without_markdown" src="https://github.com/amazon-connect/amazon-connect-chat-interface/assets/60903378/4034b432-9900-401e-bc57-69130c57b0d7">




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
