### PR TITLE
bumped the version for connect-chat-js from 2.2.4 to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@emotion/core": "^10.0.35",
     "@svgr/webpack": "^6.2.1",
     "@types/jest": "^28.0.0",
-    "amazon-connect-chatjs": "^2.2.4",
+    "amazon-connect-chatjs": "^2.3.0",
     "core-js": "^3.8.3",
     "dompurify": "^3.0.3",
     "draft-js": "^0.11.7",


### PR DESCRIPTION
*Issue #, if available:* local testing for connect chat was failing

*Description of changes:*
bumped the version for connect-chat-js from 2.2.4 to 2.3.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
