### PR TITLE
upgrade chat js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@emotion/core": "^10.0.35",
     "@svgr/webpack": "^6.2.1",
     "@types/jest": "^28.0.0",
-    "amazon-connect-chatjs": "^2.2.4",
+    "amazon-connect-chatjs": "^2.2.5",
     "core-js": "^3.8.3",
     "dompurify": "^3.1.3",
     "draft-js": "^0.11.7",


### PR DESCRIPTION
*Issue 257, if available:* https://github.com/amazon-connect/amazon-connect-chat-interface/issues/257

*Description of changes:*


Upgrading chat js version to fix initialization failure when using customChatInterfaceUrl
