### PR TITLE
Allow creation of chatSession from startChatResponse parameters

### DIFF
--- a/src/components/Chat/ChatInitiator.js
+++ b/src/components/Chat/ChatInitiator.js
@@ -32,6 +32,9 @@ function safeParse(jsonString, defaultValue) {
  * @returns {Promise} Promise object that resolves to chatDetails objects
  */
 export function initiateChat(input) {
+  if (input.chatSessionParameters) {
+    return { startChatResult: input.chatSessionParameters };
+  }
   const initiateChatRequest = {
     InstanceId: input.instanceId,
     ContactFlowId: input.contactFlowId,

--- a/src/components/Chat/ChatInterface.js
+++ b/src/components/Chat/ChatInterface.js
@@ -14,6 +14,7 @@ class ChatInterface {
     region: "",
     stage: "prod",
     contactAttributes: {},
+    chatSessionParameters: {},
     featurePermissions: {}
   }
 


### PR DESCRIPTION
*Description of changes:*
Added chatSessionParameters to ChatInterface.js that would be obtained by a call to startChatApi. If chatSessionParameters are present, initiateChat skips making a call to the provided backend startChat API and creates a chat session directly with the provided parameters. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
