### PR TITLE
Add standalone chat widget and Lambda proxy for Amazon Connect

### DIFF
--- a/lambda/index.mjs
+++ b/lambda/index.mjs
@@ -1,0 +1,162 @@
+import { ConnectClient, StartChatContactCommand } from "@aws-sdk/client-connect";
+
+// Explicit region bypasses environment-discovery delays in Node 24.x Lambda runtime.
+const REGION = "ap-southeast-2";
+const PARTICIPANT_SERVICE_ENDPOINT = `https://participant.connect.${REGION}.amazonaws.com`;
+
+// CORS headers are defined once and applied to EVERY return path so the browser
+// network panel never masks execution errors behind a generic CORS failure.
+const CORS_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Headers": "Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-Bearer",
+    "Access-Control-Allow-Methods": "POST,OPTIONS",
+    "Content-Type": "application/json"
+};
+
+// Client is instantiated at module scope for connection reuse across warm invocations.
+const connectClient = new ConnectClient({ region: REGION });
+
+export const handler = async (event) => {
+    console.log("Incoming request:", JSON.stringify({
+        httpMethod: event.httpMethod,
+        path: event.path,
+        sourceIp: event.requestContext?.identity?.sourceIp,
+        userAgent: event.requestContext?.identity?.userAgent,
+        bodyLength: event.body ? event.body.length : 0
+    }));
+
+    // ── CORS Preflight ─────────────────────────────────────────────────────────
+    if (event.httpMethod === "OPTIONS") {
+        console.log("CORS preflight handled.");
+        return { statusCode: 200, headers: CORS_HEADERS, body: "" };
+    }
+
+    if (event.httpMethod !== "POST") {
+        console.warn("Method not allowed:", event.httpMethod);
+        return {
+            statusCode: 405,
+            headers: { ...CORS_HEADERS, "Allow": "POST,OPTIONS" },
+            body: JSON.stringify({ error: "Method not allowed." })
+        };
+    }
+
+    // ── Parse Body ─────────────────────────────────────────────────────────────
+    let body;
+    try {
+        body = JSON.parse(event.body || "{}");
+    } catch (parseErr) {
+        console.error("Request body JSON parse failure:", parseErr.message);
+        return {
+            statusCode: 400,
+            headers: CORS_HEADERS,
+            body: JSON.stringify({ error: "Request body must be valid JSON." })
+        };
+    }
+
+    const { customerName, customerEmail } = body;
+
+    // ── Input Validation ───────────────────────────────────────────────────────
+    if (!customerName || typeof customerName !== "string" || customerName.trim().length < 1) {
+        console.warn("Validation failed: customerName missing or invalid.");
+        return {
+            statusCode: 400,
+            headers: CORS_HEADERS,
+            body: JSON.stringify({ error: "customerName is required and must be a non-empty string." })
+        };
+    }
+
+    if (!customerEmail || typeof customerEmail !== "string") {
+        console.warn("Validation failed: customerEmail missing or not a string.");
+        return {
+            statusCode: 400,
+            headers: CORS_HEADERS,
+            body: JSON.stringify({ error: "customerEmail is required." })
+        };
+    }
+
+    const emailRegex = /^[^\s@]{1,64}@[^\s@]{1,255}$/;
+    if (!emailRegex.test(customerEmail.trim())) {
+        console.warn("Validation failed: customerEmail format invalid.");
+        return {
+            statusCode: 400,
+            headers: CORS_HEADERS,
+            body: JSON.stringify({ error: "customerEmail must be a valid email address." })
+        };
+    }
+
+    // ── Defensive Server-Side Truncation ───────────────────────────────────────
+    // Applied after validation so error messages reflect the original input intent.
+    const sanitizedName  = customerName.trim().substring(0, 50);
+    const sanitizedEmail = customerEmail.trim().substring(0, 100);
+
+    console.log("Processing chat request. Customer:", sanitizedName, "| Email:", sanitizedEmail);
+
+    // ── Environment Variable Resolution ───────────────────────────────────────
+    const instanceId    = process.env.CONNECT_INSTANCE_ID;
+    const contactFlowId = process.env.CONNECT_CONTACT_FLOW_ID;
+
+    if (!instanceId || !contactFlowId) {
+        console.error(
+            "FATAL: Missing required Lambda environment variables.",
+            "CONNECT_INSTANCE_ID present:", !!instanceId,
+            "CONNECT_CONTACT_FLOW_ID present:", !!contactFlowId
+        );
+        return {
+            statusCode: 500,
+            headers: CORS_HEADERS,
+            body: JSON.stringify({ error: "Server configuration error. Please contact an administrator." })
+        };
+    }
+
+    // ── StartChatContact ───────────────────────────────────────────────────────
+    try {
+        const command = new StartChatContactCommand({
+            InstanceId:    instanceId,
+            ContactFlowId: contactFlowId,
+            ParticipantDetails: {
+                DisplayName: sanitizedName
+            },
+            Attributes: {
+                customerName:  sanitizedName,
+                customerEmail: sanitizedEmail,
+                channel:       "WEB_CHAT_WIDGET"
+            },
+            SupportedMessagingContentTypes: [
+                "text/plain",
+                "text/markdown"
+            ]
+        });
+
+        const response = await connectClient.send(command);
+
+        console.log(
+            "StartChatContact success.",
+            "ContactId:", response.ContactId,
+            "| ParticipantId:", response.ParticipantId
+        );
+
+        return {
+            statusCode: 200,
+            headers: CORS_HEADERS,
+            body: JSON.stringify({
+                contactId:                  response.ContactId,
+                participantId:              response.ParticipantId,
+                participantToken:           response.ParticipantToken,
+                participantServiceEndpoint: PARTICIPANT_SERVICE_ENDPOINT
+            })
+        };
+
+    } catch (awsErr) {
+        console.error(
+            "StartChatContact AWS SDK error.",
+            "Name:", awsErr.name,
+            "| Message:", awsErr.message,
+            "| RequestId:", awsErr.$metadata?.requestId
+        );
+        return {
+            statusCode: 500,
+            headers: CORS_HEADERS,
+            body: JSON.stringify({ error: "Failed to initiate chat session. Please try again." })
+        };
+    }
+};

--- a/widget/index.html
+++ b/widget/index.html
@@ -1,0 +1,1095 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Customer Support Chat</title>
+    <style>
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+        :root {
+            --primary:        #0052cc;
+            --primary-dark:   #003d99;
+            --primary-light:  #e6f0ff;
+            --bubble-agent:   #f0f4f8;
+            --bubble-cust:    #0052cc;
+            --text-agent:     #1a1a2e;
+            --text-cust:      #ffffff;
+            --surface:        #ffffff;
+            --border:         #e2e8f0;
+            --muted:          #64748b;
+            --success:        #22c55e;
+            --warning:        #f59e0b;
+            --error:          #ef4444;
+            --shadow:         0 20px 60px rgba(0,0,0,0.15), 0 4px 20px rgba(0,0,0,0.1);
+            --radius:         16px;
+            --radius-sm:      8px;
+            --ease:           0.25s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        /* ── Launcher ──────────────────────────────────────── */
+        #chat-launcher {
+            position: fixed;
+            bottom: 24px; right: 24px;
+            width: 60px; height: 60px;
+            border-radius: 50%;
+            background: var(--primary);
+            border: none;
+            cursor: pointer;
+            box-shadow: 0 4px 20px rgba(0,82,204,0.4);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            transition: transform var(--ease), box-shadow var(--ease);
+            z-index: 1000;
+        }
+        #chat-launcher:hover {
+            transform: scale(1.1);
+            box-shadow: 0 6px 28px rgba(0,82,204,0.5);
+        }
+        #chat-launcher svg {
+            width: 28px; height: 28px;
+            fill: #fff;
+            position: absolute;
+            transition: opacity var(--ease), transform var(--ease);
+        }
+        #chat-launcher .icon-close { opacity: 0; transform: rotate(-90deg); }
+        #chat-launcher.open .icon-chat  { opacity: 0; transform: rotate(90deg); }
+        #chat-launcher.open .icon-close { opacity: 1; transform: rotate(0deg); }
+
+        #unread-badge {
+            position: absolute; top: -4px; right: -4px;
+            background: var(--error);
+            color: #fff;
+            border-radius: 50%;
+            width: 20px; height: 20px;
+            font-size: 11px; font-weight: 700;
+            display: none;
+            align-items: center; justify-content: center;
+            border: 2px solid #fff;
+        }
+
+        /* ── Widget Shell ──────────────────────────────────── */
+        #chat-widget {
+            position: fixed;
+            bottom: 96px; right: 24px;
+            width: 380px;
+            max-height: 620px;
+            background: var(--surface);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+            z-index: 999;
+            transform: scale(0.95) translateY(20px);
+            opacity: 0;
+            pointer-events: none;
+            transition: transform var(--ease), opacity var(--ease);
+            transform-origin: bottom right;
+        }
+        #chat-widget.open {
+            transform: scale(1) translateY(0);
+            opacity: 1;
+            pointer-events: all;
+        }
+
+        /* ── Header ────────────────────────────────────────── */
+        .chat-header {
+            background: var(--primary);
+            color: #fff;
+            padding: 16px 20px;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            flex-shrink: 0;
+        }
+        .header-avatar {
+            width: 40px; height: 40px;
+            border-radius: 50%;
+            background: rgba(255,255,255,0.2);
+            display: flex; align-items: center; justify-content: center;
+            font-size: 18px; flex-shrink: 0;
+        }
+        .header-info { flex: 1; min-width: 0; }
+        .header-title    { font-size: 15px; font-weight: 600; line-height: 1.2; }
+        .header-subtitle { font-size: 12px; opacity: 0.85; margin-top: 2px; }
+
+        #conn-dot {
+            width: 8px; height: 8px;
+            border-radius: 50%;
+            background: #94a3b8;
+            flex-shrink: 0;
+            transition: background var(--ease);
+        }
+        #conn-dot.connected   { background: var(--success); box-shadow: 0 0 6px var(--success); }
+        #conn-dot.connecting  { background: var(--warning); animation: pulse 1.5s infinite; }
+        #conn-dot.error-state { background: var(--error); }
+
+        @keyframes pulse {
+            0%,100% { opacity: 1; } 50% { opacity: 0.4; }
+        }
+
+        /* ── Screens ───────────────────────────────────────── */
+        .screen { flex: 1; display: flex; flex-direction: column; overflow: hidden; }
+        .screen.hidden { display: none !important; }
+
+        /* ── Pre-Chat Form ─────────────────────────────────── */
+        #pre-chat-screen { padding: 28px 24px; overflow-y: auto; }
+
+        .form-title    { font-size: 18px; font-weight: 700; color: #1a1a2e; margin-bottom: 6px; }
+        .form-subtitle { font-size: 14px; color: var(--muted); margin-bottom: 28px; line-height: 1.5; }
+
+        .form-group { margin-bottom: 18px; }
+        .form-group label {
+            display: block;
+            font-size: 13px; font-weight: 600;
+            color: #374151; margin-bottom: 6px;
+        }
+        .form-group input {
+            width: 100%;
+            padding: 11px 14px;
+            border: 1.5px solid var(--border);
+            border-radius: var(--radius-sm);
+            font-size: 14px; font-family: inherit;
+            color: #1a1a2e; background: #fafafa;
+            outline: none;
+            transition: border-color var(--ease), box-shadow var(--ease);
+        }
+        .form-group input:focus {
+            border-color: var(--primary);
+            box-shadow: 0 0 0 3px rgba(0,82,204,0.12);
+            background: #fff;
+        }
+        .form-group input.invalid {
+            border-color: var(--error);
+            box-shadow: 0 0 0 3px rgba(239,68,68,0.12);
+        }
+        .field-error {
+            font-size: 12px; color: var(--error);
+            margin-top: 5px; display: none;
+        }
+        .field-error.visible { display: block; }
+
+        .btn-primary {
+            width: 100%;
+            padding: 13px;
+            background: var(--primary); color: #fff;
+            border: none; border-radius: var(--radius-sm);
+            font-size: 15px; font-weight: 600; font-family: inherit;
+            cursor: pointer;
+            display: flex; align-items: center; justify-content: center; gap: 8px;
+            transition: background var(--ease), transform var(--ease);
+            margin-top: 8px;
+        }
+        .btn-primary:hover:not(:disabled)  { background: var(--primary-dark); }
+        .btn-primary:active:not(:disabled) { transform: scale(0.99); }
+        .btn-primary:disabled { opacity: 0.65; cursor: not-allowed; }
+
+        .spinner {
+            width: 18px; height: 18px;
+            border: 2px solid rgba(255,255,255,0.35);
+            border-top-color: #fff;
+            border-radius: 50%;
+            animation: spin 0.7s linear infinite;
+            display: none;
+        }
+        .btn-primary.loading .spinner  { display: block; }
+        .btn-primary.loading .btn-text { display: none; }
+
+        @keyframes spin { to { transform: rotate(360deg); } }
+
+        .form-api-error {
+            font-size: 13px; color: var(--error);
+            text-align: center; margin-top: 12px;
+            padding: 10px; background: #fff5f5;
+            border-radius: var(--radius-sm);
+            border: 1px solid #fecaca;
+            display: none;
+        }
+        .form-api-error.visible { display: block; }
+
+        /* ── Chat Screen ───────────────────────────────────── */
+        #chat-screen { display: none; }
+        #chat-screen.active {
+            display: flex; flex-direction: column;
+            flex: 1; overflow: hidden;
+        }
+
+        /* ── Messages ──────────────────────────────────────── */
+        #messages {
+            flex: 1;
+            overflow-y: auto;
+            padding: 16px;
+            display: flex; flex-direction: column; gap: 4px;
+            scroll-behavior: smooth;
+        }
+        #messages::-webkit-scrollbar { width: 4px; }
+        #messages::-webkit-scrollbar-track { background: transparent; }
+        #messages::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 2px; }
+
+        .msg-group {
+            display: flex; flex-direction: column; gap: 2px;
+            margin-bottom: 8px;
+        }
+        .msg-group.customer { align-items: flex-end; }
+        .msg-group.agent    { align-items: flex-start; }
+        .msg-group.system   { align-items: center; }
+
+        .msg-sender {
+            font-size: 11px; color: var(--muted);
+            margin-bottom: 3px; padding: 0 4px;
+        }
+        .msg-bubble {
+            max-width: 78%;
+            padding: 10px 14px;
+            border-radius: 14px;
+            font-size: 14px; line-height: 1.5;
+            word-wrap: break-word; white-space: pre-wrap;
+        }
+        .msg-group.customer .msg-bubble {
+            background: var(--bubble-cust);
+            color: var(--text-cust);
+            border-bottom-right-radius: 4px;
+        }
+        .msg-group.agent .msg-bubble {
+            background: var(--bubble-agent);
+            color: var(--text-agent);
+            border-bottom-left-radius: 4px;
+        }
+        .msg-group.system .msg-bubble {
+            background: #f1f5f9; color: var(--muted);
+            font-size: 12px; border-radius: 20px;
+            padding: 6px 14px; max-width: 90%; text-align: center;
+        }
+        .msg-time {
+            font-size: 10px; color: var(--muted);
+            padding: 0 4px; margin-top: 2px;
+        }
+        .msg-group.customer .msg-time { text-align: right; }
+
+        /* ── Typing Indicator ──────────────────────────────── */
+        #typing-indicator {
+            display: none;
+            align-items: center; gap: 8px;
+            padding: 4px 16px 8px;
+        }
+        #typing-indicator.visible { display: flex; }
+        .typing-dots {
+            display: flex; gap: 4px;
+            background: var(--bubble-agent);
+            padding: 10px 14px;
+            border-radius: 14px;
+            border-bottom-left-radius: 4px;
+        }
+        .typing-dot {
+            width: 6px; height: 6px;
+            background: #94a3b8; border-radius: 50%;
+            animation: bounce 1.2s infinite;
+        }
+        .typing-dot:nth-child(2) { animation-delay: 0.2s; }
+        .typing-dot:nth-child(3) { animation-delay: 0.4s; }
+        @keyframes bounce {
+            0%,60%,100% { transform: translateY(0); }
+            30%          { transform: translateY(-6px); }
+        }
+        .typing-label { font-size: 12px; color: var(--muted); }
+
+        /* ── Input Area ────────────────────────────────────── */
+        .input-area {
+            padding: 12px 16px;
+            border-top: 1px solid var(--border);
+            background: #fff;
+            flex-shrink: 0;
+        }
+        .input-row { display: flex; gap: 8px; align-items: flex-end; }
+
+        #msg-input {
+            flex: 1;
+            padding: 10px 14px;
+            border: 1.5px solid var(--border);
+            border-radius: 22px;
+            font-size: 14px; font-family: inherit;
+            resize: none; outline: none;
+            min-height: 42px; max-height: 120px;
+            line-height: 1.4;
+            background: #fafafa; color: #1a1a2e;
+            transition: border-color var(--ease);
+        }
+        #msg-input:focus { border-color: var(--primary); background: #fff; }
+        #msg-input:disabled { opacity: 0.6; cursor: not-allowed; }
+
+        #send-btn {
+            width: 42px; height: 42px;
+            border-radius: 50%;
+            background: var(--primary);
+            border: none; cursor: pointer;
+            display: flex; align-items: center; justify-content: center;
+            flex-shrink: 0;
+            transition: background var(--ease), transform var(--ease);
+        }
+        #send-btn:hover:not(:disabled)  { background: var(--primary-dark); }
+        #send-btn:active:not(:disabled) { transform: scale(0.92); }
+        #send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+        #send-btn svg { fill: #fff; width: 18px; height: 18px; }
+
+        .input-meta {
+            display: flex; justify-content: space-between; align-items: center;
+            margin-top: 6px; padding: 0 4px;
+        }
+        #char-count { font-size: 11px; color: var(--muted); }
+        #char-count.warn   { color: var(--warning); }
+        #char-count.danger { color: var(--error); }
+        .enter-hint { font-size: 11px; color: #cbd5e1; }
+
+        /* ── Status Bar ────────────────────────────────────── */
+        #status-bar {
+            font-size: 12px; color: var(--muted);
+            text-align: center; padding: 8px;
+            border-top: 1px solid var(--border);
+            background: #fafafa; display: none;
+        }
+        #status-bar.visible    { display: block; }
+        #status-bar.is-error   { color: var(--error); }
+
+        /* ── Ended Overlay ─────────────────────────────────── */
+        #ended-overlay {
+            display: none;
+            flex-direction: column; align-items: center; justify-content: center;
+            padding: 32px 24px; text-align: center; gap: 12px;
+            position: absolute; inset: 0;
+            background: #fff; z-index: 10;
+        }
+        #ended-overlay.visible { display: flex; }
+        .ended-icon    { font-size: 48px; }
+        .ended-title   { font-size: 17px; font-weight: 700; color: #1a1a2e; }
+        .ended-sub     { font-size: 14px; color: var(--muted); line-height: 1.6; }
+        .btn-new-chat  {
+            padding: 11px 28px;
+            background: var(--primary); color: #fff;
+            border: none; border-radius: var(--radius-sm);
+            font-size: 14px; font-weight: 600; font-family: inherit;
+            cursor: pointer; margin-top: 8px;
+            transition: background var(--ease);
+        }
+        .btn-new-chat:hover { background: var(--primary-dark); }
+
+        /* ── Demo Page ─────────────────────────────────────── */
+        .demo-hero {
+            text-align: center; color: #fff; padding: 20px; user-select: none;
+        }
+        .demo-hero h1 {
+            font-size: 2.5rem; font-weight: 700; margin-bottom: 12px;
+            text-shadow: 0 2px 10px rgba(0,0,0,0.2);
+        }
+        .demo-hero p { font-size: 1.1rem; opacity: 0.85; }
+
+        /* ── Responsive ────────────────────────────────────── */
+        @media (max-width: 440px) {
+            #chat-widget { width: calc(100vw - 16px); right: 8px; bottom: 80px; }
+        }
+    </style>
+</head>
+<body>
+
+<div class="demo-hero">
+    <h1>Customer Support Portal</h1>
+    <p>Click the chat button in the bottom-right corner to get started.</p>
+</div>
+
+<!-- ── Launcher ───────────────────────────────────────────── -->
+<button id="chat-launcher" aria-label="Open support chat" aria-expanded="false">
+    <svg class="icon-chat" viewBox="0 0 24 24"><path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H5.17L4 17.17V4h16v12z"/></svg>
+    <svg class="icon-close" viewBox="0 0 24 24"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>
+    <span id="unread-badge" role="status" aria-live="polite" aria-label="Unread messages"></span>
+</button>
+
+<!-- ── Widget ─────────────────────────────────────────────── -->
+<div id="chat-widget" role="dialog" aria-label="Customer Support Chat" aria-modal="true">
+
+    <!-- Header -->
+    <div class="chat-header">
+        <div class="header-avatar" aria-hidden="true">💬</div>
+        <div class="header-info">
+            <div class="header-title">Customer Support</div>
+            <div class="header-subtitle" id="header-sub">We typically reply in minutes</div>
+        </div>
+        <div id="conn-dot" title="Disconnected" aria-hidden="true"></div>
+    </div>
+
+    <!-- Pre-Chat Screen -->
+    <div id="pre-chat-screen" class="screen">
+        <h2 class="form-title">Start a conversation</h2>
+        <p class="form-subtitle">Fill in your details and we'll connect you with a support agent right away.</p>
+
+        <form id="pre-chat-form" novalidate>
+            <div class="form-group">
+                <label for="inp-name">Full Name <span aria-hidden="true" style="color:var(--error)">*</span></label>
+                <input type="text"  id="inp-name"  name="customerName"
+                       placeholder="e.g. Jane Smith"
+                       autocomplete="name" maxlength="50" required
+                       aria-describedby="err-name" />
+                <span id="err-name" class="field-error" role="alert">Please enter your full name.</span>
+            </div>
+
+            <div class="form-group">
+                <label for="inp-email">Email Address <span aria-hidden="true" style="color:var(--error)">*</span></label>
+                <input type="email" id="inp-email" name="customerEmail"
+                       placeholder="e.g. jane@example.com"
+                       autocomplete="email" maxlength="100" required
+                       aria-describedby="err-email" />
+                <span id="err-email" class="field-error" role="alert">Please enter a valid email address.</span>
+            </div>
+
+            <button type="submit" class="btn-primary" id="start-btn">
+                <span class="btn-text">Start Chat</span>
+                <span class="spinner" aria-hidden="true"></span>
+            </button>
+        </form>
+
+        <div id="form-api-error" class="form-api-error" role="alert"></div>
+    </div>
+
+    <!-- Chat Screen -->
+    <div id="chat-screen" class="screen" style="position:relative;">
+
+        <div id="messages" role="log" aria-live="polite" aria-atomic="false" aria-label="Chat messages"></div>
+
+        <div id="typing-indicator" aria-live="polite" aria-label="Agent is typing">
+            <div class="typing-dots" aria-hidden="true">
+                <div class="typing-dot"></div>
+                <div class="typing-dot"></div>
+                <div class="typing-dot"></div>
+            </div>
+            <span class="typing-label">Agent is typing…</span>
+        </div>
+
+        <div id="status-bar"></div>
+
+        <div class="input-area">
+            <div class="input-row">
+                <textarea id="msg-input"
+                          placeholder="Type a message…"
+                          rows="1" maxlength="1024"
+                          aria-label="Chat message"
+                          disabled></textarea>
+                <button id="send-btn" aria-label="Send message" disabled>
+                    <svg viewBox="0 0 24 24"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/></svg>
+                </button>
+            </div>
+            <div class="input-meta">
+                <span id="char-count">0 / 1024</span>
+                <span class="enter-hint">Enter to send · Shift+Enter for new line</span>
+            </div>
+        </div>
+
+        <!-- Ended overlay sits inside chat screen -->
+        <div id="ended-overlay">
+            <div class="ended-icon" aria-hidden="true">✅</div>
+            <h3 class="ended-title">Chat Ended</h3>
+            <p class="ended-sub">Your session has ended. Thank you for contacting us!</p>
+            <button class="btn-new-chat" id="new-chat-btn">Start New Chat</button>
+        </div>
+    </div>
+
+</div>
+
+<script>
+/**
+ * Amazon Connect Chat Widget
+ * ──────────────────────────────────────────────────────────────
+ * CONFIG.API_GATEWAY_URL is the only AWS-specific value required
+ * on the frontend. No Instance IDs, Contact Flow IDs, or region
+ * strings are embedded here — all are resolved on the backend.
+ * The participantServiceEndpoint is returned by the Lambda so
+ * this file stays endpoint-agnostic.
+ */
+const CONFIG = {
+    API_GATEWAY_URL: 'https://YOUR_API_GATEWAY_ID.execute-api.ap-southeast-2.amazonaws.com/prod/start-chat'
+};
+
+// ── State ──────────────────────────────────────────────────────
+const S = {
+    participantToken:           null,  // stored for WebSocket reconnection
+    connectionToken:            null,
+    participantServiceEndpoint: null,
+    websocket:                  null,
+    wsUrl:                      null,  // cached for reconnection
+    pingTimer:                  null,
+    reconnectTimer:             null,
+    reconnectAttempts:          0,
+    MAX_RECONNECT:              5,
+    RECONNECT_BASE_MS:          2000,
+    customerName:               '',
+    chatActive:                 false,
+    widgetOpen:                 false,
+    unreadCount:                0,
+    lastTypingSentMs:           0,
+    TYPING_THROTTLE_MS:         3000,
+    typingClearTimer:           null,
+    MAX_MSG_LEN:                1024
+};
+
+// ── DOM ────────────────────────────────────────────────────────
+const $ = id => document.getElementById(id);
+const D = {
+    launcher:    $('chat-launcher'),
+    widget:      $('chat-widget'),
+    badge:       $('unread-badge'),
+    connDot:     $('conn-dot'),
+    headerSub:   $('header-sub'),
+    preChatScr:  $('pre-chat-screen'),
+    chatScr:     $('chat-screen'),
+    form:        $('pre-chat-form'),
+    inpName:     $('inp-name'),
+    inpEmail:    $('inp-email'),
+    errName:     $('err-name'),
+    errEmail:    $('err-email'),
+    startBtn:    $('start-btn'),
+    apiError:    $('form-api-error'),
+    messages:    $('messages'),
+    typing:      $('typing-indicator'),
+    msgInput:    $('msg-input'),
+    sendBtn:     $('send-btn'),
+    charCount:   $('char-count'),
+    statusBar:   $('status-bar'),
+    endedOverlay:$('ended-overlay'),
+    newChatBtn:  $('new-chat-btn')
+};
+
+// ── Utilities ──────────────────────────────────────────────────
+function uuid() {
+    return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+        (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c/4).toString(16));
+}
+
+function fmtTime(iso) {
+    return (iso ? new Date(iso) : new Date())
+        .toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+function setConn(state) {
+    D.connDot.className = '';
+    if (state) D.connDot.classList.add(state);
+    const labels = { connected:'Connected', connecting:'Connecting…', 'error-state':'Connection error' };
+    D.connDot.title = labels[state] || 'Disconnected';
+}
+
+function showStatus(msg, isErr = false) {
+    D.statusBar.textContent = msg;
+    D.statusBar.className = 'visible' + (isErr ? ' is-error' : '');
+}
+function hideStatus() { D.statusBar.className = ''; }
+
+// ── Launcher toggle ────────────────────────────────────────────
+D.launcher.addEventListener('click', () => {
+    S.widgetOpen = !S.widgetOpen;
+    D.widget.classList.toggle('open', S.widgetOpen);
+    D.launcher.classList.toggle('open', S.widgetOpen);
+    D.launcher.setAttribute('aria-expanded', String(S.widgetOpen));
+
+    if (S.widgetOpen) {
+        S.unreadCount = 0;
+        D.badge.style.display = 'none';
+        setTimeout(() => (S.chatActive ? D.msgInput : D.inpName).focus(), 280);
+    }
+});
+
+// ── Form validation ────────────────────────────────────────────
+const EMAIL_RE = /^[^\s@]{1,64}@[^\s@]{1,255}$/;
+
+function validateForm() {
+    let ok = true;
+    const name  = D.inpName.value.trim();
+    const email = D.inpEmail.value.trim();
+
+    if (name.length < 2) {
+        D.inpName.classList.add('invalid');
+        D.errName.classList.add('visible');
+        ok = false;
+    } else {
+        D.inpName.classList.remove('invalid');
+        D.errName.classList.remove('visible');
+    }
+
+    if (!EMAIL_RE.test(email)) {
+        D.inpEmail.classList.add('invalid');
+        D.errEmail.classList.add('visible');
+        ok = false;
+    } else {
+        D.inpEmail.classList.remove('invalid');
+        D.errEmail.classList.remove('visible');
+    }
+    return ok;
+}
+
+D.inpName.addEventListener('input', () => {
+    if (D.inpName.value.trim().length >= 2) {
+        D.inpName.classList.remove('invalid');
+        D.errName.classList.remove('visible');
+    }
+});
+D.inpEmail.addEventListener('input', () => {
+    if (EMAIL_RE.test(D.inpEmail.value.trim())) {
+        D.inpEmail.classList.remove('invalid');
+        D.errEmail.classList.remove('visible');
+    }
+});
+
+// ── Form submit: start chat ────────────────────────────────────
+D.form.addEventListener('submit', async e => {
+    e.preventDefault();
+    if (!validateForm()) return;
+
+    D.apiError.className = 'form-api-error';
+    D.startBtn.classList.add('loading');
+    D.startBtn.disabled = true;
+
+    const customerName  = D.inpName.value.trim();
+    const customerEmail = D.inpEmail.value.trim();
+    S.customerName = customerName;
+
+    try {
+        console.log('[Chat] Requesting chat session for:', customerName);
+        const res = await fetch(CONFIG.API_GATEWAY_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ customerName, customerEmail })
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+
+        console.log('[Chat] Session created. ContactId:', data.contactId);
+
+        S.participantServiceEndpoint = data.participantServiceEndpoint;
+        S.participantToken           = data.participantToken;
+
+        await createParticipantConnection(data.participantToken);
+
+    } catch (err) {
+        console.error('[Chat] Start-chat error:', err);
+        D.apiError.textContent = err.message || 'Unable to connect. Please try again.';
+        D.apiError.className = 'form-api-error visible';
+    } finally {
+        D.startBtn.classList.remove('loading');
+        D.startBtn.disabled = false;
+    }
+});
+
+// ── Create Participant Connection ──────────────────────────────
+async function createParticipantConnection(bearerToken) {
+    console.log('[Chat] Creating participant connection…');
+    setConn('connecting');
+    D.headerSub.textContent = 'Connecting…';
+
+    const res = await fetch(`${S.participantServiceEndpoint}/participant/connection`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'X-Amz-Bearer': bearerToken
+        },
+        body: JSON.stringify({ Type: ['WEBSOCKET', 'CONNECTION_CREDENTIALS'] })
+    });
+
+    if (!res.ok) {
+        const txt = await res.text();
+        console.error('[Chat] CreateParticipantConnection failed:', res.status, txt);
+        throw new Error('Failed to create participant connection.');
+    }
+
+    const conn = await res.json();
+    console.log('[Chat] Participant connection credentials received.');
+
+    S.connectionToken = conn.ConnectionCredentials.ConnectionToken;
+    S.wsUrl           = conn.Websocket.Url;
+
+    switchToChatScreen();
+    openWebSocket(S.wsUrl);
+}
+
+// ── Screen Transition ──────────────────────────────────────────
+function switchToChatScreen() {
+    D.preChatScr.classList.add('hidden');
+    D.chatScr.style.display = 'flex';
+    D.chatScr.classList.add('active');
+    S.chatActive = true;
+}
+
+// ── WebSocket ──────────────────────────────────────────────────
+function openWebSocket(wsUrl) {
+    console.log('[Chat] Opening WebSocket connection…');
+
+    if (S.websocket) {
+        S.websocket.onclose = null;
+        S.websocket.close();
+    }
+
+    const ws = new WebSocket(wsUrl);
+    S.websocket = ws;
+
+    ws.onopen = () => {
+        console.log('[Chat] WebSocket open.');
+        S.reconnectAttempts = 0;
+        setConn('connected');
+        D.headerSub.textContent = 'Connected · Support Agent';
+        D.msgInput.disabled = false;
+        D.sendBtn.disabled  = false;
+        hideStatus();
+        D.msgInput.focus();
+
+        ws.send(JSON.stringify({
+            topic: 'aws/subscribe',
+            content: { topics: ['aws/chat'] }
+        }));
+
+        startPing(ws);
+    };
+
+    ws.onmessage = evt => handleWsMessage(evt);
+
+    ws.onerror = err => {
+        console.error('[Chat] WebSocket error:', err);
+        setConn('error-state');
+    };
+
+    ws.onclose = evt => {
+        console.warn('[Chat] WebSocket closed. Code:', evt.code, 'Reason:', evt.reason);
+        stopPing();
+        setConn('disconnected');
+
+        if (!S.chatActive) return;
+
+        S.reconnectAttempts++;
+        if (S.reconnectAttempts > S.MAX_RECONNECT) {
+            console.error('[Chat] Max reconnect attempts reached.');
+            showStatus('Connection lost. Please start a new chat.', true);
+            endChat('reconnect-limit');
+            return;
+        }
+
+        const delay = S.RECONNECT_BASE_MS * Math.pow(1.5, S.reconnectAttempts - 1);
+        console.log(`[Chat] Reconnecting in ${Math.round(delay)}ms (attempt ${S.reconnectAttempts}/${S.MAX_RECONNECT})`);
+        showStatus(`Reconnecting… (${S.reconnectAttempts}/${S.MAX_RECONNECT})`);
+        D.msgInput.disabled = true;
+        D.sendBtn.disabled  = true;
+
+        // Re-use stored participant token to obtain a fresh WebSocket URL.
+        S.reconnectTimer = setTimeout(async () => {
+            try {
+                await createParticipantConnection(S.participantToken);
+            } catch (err) {
+                console.error('[Chat] Reconnect failed:', err.message);
+                showStatus('Reconnection failed. Please start a new chat.', true);
+                endChat('reconnect-error');
+            }
+        }, delay);
+    };
+}
+
+// ── Heartbeat ──────────────────────────────────────────────────
+function startPing(ws) {
+    stopPing();
+    S.pingTimer = setInterval(() => {
+        if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({ topic: 'aws/ping' }));
+        }
+    }, 30_000);
+}
+function stopPing() {
+    if (S.pingTimer) { clearInterval(S.pingTimer); S.pingTimer = null; }
+}
+
+// ── WebSocket Message Handler ──────────────────────────────────
+function handleWsMessage(evt) {
+    let msg;
+    try { msg = JSON.parse(evt.data); }
+    catch { console.warn('[Chat] Non-JSON WS frame:', evt.data); return; }
+
+    const { topic, contentType = '', type: msgType, participantRole = '' } = msg;
+
+    console.log('[Chat] WS event:', topic, contentType);
+
+    if (topic === 'aws/subscribe' || topic === 'aws/ping' || topic === 'aws/pong') return;
+    if (topic !== 'aws/chat') return;
+
+    const role = participantRole.toUpperCase();
+
+    // Incoming chat message
+    if (msgType === 'MESSAGE' &&
+        (contentType === 'text/plain' || contentType === 'text/markdown')) {
+        // Suppress echo of own messages (optimistically rendered on send)
+        if (role === 'CUSTOMER') return;
+        appendMsg({
+            role: 'agent',
+            content: msg.content || '',
+            sender: msg.displayName || 'Agent',
+            ts: msg.absoluteTime,
+            id: msg.id
+        });
+        clearTyping();
+        bumpUnread();
+        return;
+    }
+
+    // Typing
+    if (contentType === 'application/vnd.amazonaws.connect.event.typing') {
+        if (role !== 'CUSTOMER') showTyping();
+        return;
+    }
+
+    // Participant joined
+    if (contentType === 'application/vnd.amazonaws.connect.event.participant.joined') {
+        const name = msg.displayName || 'Participant';
+        if (role === 'AGENT') {
+            appendSys(`${name} has joined the chat.`);
+            D.headerSub.textContent = `Connected · ${name}`;
+        } else if (role === 'CUSTOMER') {
+            appendSys('You have joined the chat.');
+        }
+        return;
+    }
+
+    // Participant left
+    if (contentType === 'application/vnd.amazonaws.connect.event.participant.left') {
+        if (role === 'AGENT') {
+            appendSys(`${msg.displayName || 'Agent'} has left the chat.`);
+        }
+        return;
+    }
+
+    // Chat ended
+    if (contentType === 'application/vnd.amazonaws.connect.event.chat.ended') {
+        console.log('[Chat] Chat-ended event received.');
+        endChat('remote');
+    }
+}
+
+// ── Message Rendering ──────────────────────────────────────────
+function appendMsg({ role, content, sender, ts, id }) {
+    const grp = document.createElement('div');
+    grp.className = `msg-group ${role}`;
+    if (id) grp.dataset.msgId = id;
+
+    if (role !== 'system' && sender) {
+        const s = document.createElement('div');
+        s.className = 'msg-sender';
+        s.textContent = sender;
+        grp.appendChild(s);
+    }
+
+    const bubble = document.createElement('div');
+    bubble.className = 'msg-bubble';
+    bubble.textContent = content;  // textContent — no XSS risk
+    grp.appendChild(bubble);
+
+    const time = document.createElement('div');
+    time.className = 'msg-time';
+    time.textContent = fmtTime(ts);
+    grp.appendChild(time);
+
+    D.messages.appendChild(grp);
+    D.messages.scrollTop = D.messages.scrollHeight;
+}
+
+function appendSys(text) {
+    appendMsg({ role: 'system', content: text, sender: null, ts: null, id: null });
+}
+
+// ── Typing Indicator ───────────────────────────────────────────
+function showTyping() {
+    D.typing.classList.add('visible');
+    clearTimeout(S.typingClearTimer);
+    S.typingClearTimer = setTimeout(clearTyping, 5000);
+    D.messages.scrollTop = D.messages.scrollHeight;
+}
+function clearTyping() {
+    D.typing.classList.remove('visible');
+    clearTimeout(S.typingClearTimer);
+}
+
+// ── Send Typing Event (throttled) ──────────────────────────────
+async function sendTypingEvent() {
+    const now = Date.now();
+    if (now - S.lastTypingSentMs < S.TYPING_THROTTLE_MS) return;
+    if (!S.connectionToken || !S.participantServiceEndpoint) return;
+    S.lastTypingSentMs = now;
+    try {
+        await fetch(`${S.participantServiceEndpoint}/participant/event`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Amz-Bearer': S.connectionToken
+            },
+            body: JSON.stringify({
+                ContentType: 'application/vnd.amazonaws.connect.event.typing',
+                ClientToken: uuid()
+            })
+        });
+    } catch (err) {
+        console.warn('[Chat] Typing event failed (non-critical):', err.message);
+    }
+}
+
+// ── Message Input ──────────────────────────────────────────────
+D.msgInput.addEventListener('input', () => {
+    const len = D.msgInput.value.length;
+    D.charCount.textContent = `${len} / ${S.MAX_MSG_LEN}`;
+    D.charCount.classList.remove('warn', 'danger');
+    if      (len >= S.MAX_MSG_LEN * 0.90) D.charCount.classList.add('danger');
+    else if (len >= S.MAX_MSG_LEN * 0.75) D.charCount.classList.add('warn');
+
+    // Auto-grow textarea
+    D.msgInput.style.height = 'auto';
+    D.msgInput.style.height = Math.min(D.msgInput.scrollHeight, 120) + 'px';
+
+    if (D.msgInput.value.trim()) sendTypingEvent();
+});
+
+D.msgInput.addEventListener('keydown', e => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendMessage(); }
+});
+D.sendBtn.addEventListener('click', sendMessage);
+
+// ── Send Message ───────────────────────────────────────────────
+async function sendMessage() {
+    const content = D.msgInput.value.trim();
+    if (!content || !S.connectionToken || !S.participantServiceEndpoint) return;
+    if (content.length > S.MAX_MSG_LEN) return;
+
+    const clientToken = uuid();
+
+    appendMsg({
+        role: 'customer',
+        content,
+        sender: S.customerName || 'You',
+        ts: new Date().toISOString(),
+        id: clientToken
+    });
+
+    D.msgInput.value = '';
+    D.msgInput.style.height = 'auto';
+    D.charCount.textContent = `0 / ${S.MAX_MSG_LEN}`;
+    D.charCount.classList.remove('warn', 'danger');
+
+    try {
+        const res = await fetch(`${S.participantServiceEndpoint}/participant/message`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Amz-Bearer': S.connectionToken
+            },
+            body: JSON.stringify({
+                ContentType: 'text/plain',
+                Content: content,
+                ClientToken: clientToken
+            })
+        });
+        if (!res.ok) {
+            const txt = await res.text();
+            console.error('[Chat] SendMessage failed:', res.status, txt);
+            showStatus('Message failed to send. Please try again.', true);
+            setTimeout(hideStatus, 4000);
+        }
+    } catch (err) {
+        console.error('[Chat] SendMessage network error:', err);
+        showStatus('Message failed to send. Check your connection.', true);
+        setTimeout(hideStatus, 4000);
+    }
+}
+
+// ── Unread Badge ───────────────────────────────────────────────
+function bumpUnread() {
+    if (S.widgetOpen) return;
+    S.unreadCount++;
+    D.badge.textContent = S.unreadCount > 9 ? '9+' : String(S.unreadCount);
+    D.badge.style.display = 'flex';
+}
+
+// ── End Chat ───────────────────────────────────────────────────
+async function endChat(reason) {
+    console.log('[Chat] Ending session. Reason:', reason);
+    S.chatActive = false;
+    stopPing();
+    clearTimeout(S.reconnectTimer);
+
+    if (S.websocket) {
+        S.websocket.onclose = null;
+        S.websocket.close();
+        S.websocket = null;
+    }
+
+    if (S.connectionToken && S.participantServiceEndpoint) {
+        try {
+            await fetch(`${S.participantServiceEndpoint}/participant/disconnect`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Amz-Bearer': S.connectionToken
+                },
+                body: JSON.stringify({ ClientToken: uuid() })
+            });
+            console.log('[Chat] Participant disconnected.');
+        } catch (err) {
+            console.warn('[Chat] Disconnect call failed (non-critical):', err.message);
+        }
+    }
+
+    setConn('disconnected');
+    D.msgInput.disabled = true;
+    D.sendBtn.disabled  = true;
+    D.headerSub.textContent = 'Chat ended';
+    D.endedOverlay.classList.add('visible');
+    hideStatus();
+}
+
+// ── New Chat ───────────────────────────────────────────────────
+D.newChatBtn.addEventListener('click', () => {
+    // Reset state
+    Object.assign(S, {
+        participantToken: null, connectionToken: null,
+        participantServiceEndpoint: null,
+        websocket: null, wsUrl: null,
+        reconnectAttempts: 0, customerName: '',
+        chatActive: false, unreadCount: 0,
+        lastTypingSentMs: 0
+    });
+
+    // Reset UI
+    D.endedOverlay.classList.remove('visible');
+    D.chatScr.classList.remove('active');
+    D.chatScr.style.display = 'none';
+    D.messages.innerHTML = '';
+    D.preChatScr.classList.remove('hidden');
+    D.form.reset();
+    [D.inpName, D.inpEmail].forEach(el => el.classList.remove('invalid'));
+    [D.errName, D.errEmail].forEach(el => el.classList.remove('visible'));
+    D.apiError.className = 'form-api-error';
+    D.msgInput.value = '';
+    D.msgInput.style.height = 'auto';
+    D.charCount.textContent = `0 / ${S.MAX_MSG_LEN}`;
+    D.charCount.classList.remove('warn', 'danger');
+    D.headerSub.textContent = 'We typically reply in minutes';
+    D.badge.style.display = 'none';
+    setConn('disconnected');
+    hideStatus();
+    clearTyping();
+
+    setTimeout(() => D.inpName.focus(), 100);
+});
+
+// ── Init ───────────────────────────────────────────────────────
+console.log('[Chat] Widget initialised. API endpoint:', CONFIG.API_GATEWAY_URL);
+setConn('disconnected');
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Introduces a zero-dependency, production-ready chat integration:

- widget/index.html: Vanilla HTML5/CSS3/JS floating chat widget that communicates directly with the Amazon Connect Participant Service REST API and WebSocket. No AWS resource IDs are embedded on the client — only the API Gateway URL is required. Features include: pre-chat form with live validation, optimistic message rendering, throttled typing events, exponential-backoff WebSocket reconnection (up to 5 attempts using the stored participant token), heartbeat ping, and an unread badge when the widget is minimised.

- lambda/index.mjs: ES Module Lambda handler using @aws-sdk/client-connect. ConnectClient is instantiated with an explicit region ("ap-southeast-2") to bypass Node 24.x environment-discovery delays. All three return paths (200, 400, 500) carry full CORS headers. customerName is truncated to 50 chars and customerEmail to 100 chars server-side via .substring() before being passed to StartChatContactCommand. Resource IDs are read exclusively from CONNECT_INSTANCE_ID and CONNECT_CONTACT_FLOW_ID environment variables. The participantServiceEndpoint is returned to the client so the frontend never constructs an AWS URL itself.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
